### PR TITLE
FXD-581 Disable look-behind regex in whitespace.dart

### DIFF
--- a/lib/src/processing/whitespace.dart
+++ b/lib/src/processing/whitespace.dart
@@ -227,7 +227,7 @@ class WhitespaceProcessing {
   static String _removeUnnecessaryWhitespace(String text) {
     return text
         .replaceAll(RegExp(r" *(?=\n)"), "")
-        .replaceAll(RegExp(r"(?<=\n) *"), "")
+        //.replaceAll(RegExp(r"(?<=\n) *"), "") https://github.com/Sub6Resources/flutter_html/issues/1371
         .replaceAll("\n", " ")
         .replaceAll("\t", " ")
         .replaceAll(RegExp(r" {2,}"), " ");


### PR DESCRIPTION
Work around for https://github.com/Sub6Resources/flutter_html/issues/1371